### PR TITLE
add linux desktop file

### DIFF
--- a/viewer/mapsoft_mapview.desktop
+++ b/viewer/mapsoft_mapview.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Mapsoft MapView
+Comment=View and edit maps and geodata
+Exec=mapsoft_mapview %F
+Terminal=false
+Type=Application
+Categories=Graphics;Viewer;


### PR DESCRIPTION
While maintaining an [AUR package for mapsoft](https://aur.archlinux.org/packages/mapsoft/), I added [the desktop file](https://aur.archlinux.org/cgit/aur.git/tree/mapsoft_mapview.desktop?h=mapsoft) to the package. So, it would be good to contribute it back to upstream.