### PR TITLE
vmap3: add missed install targets

### DIFF
--- a/vector/vmap3/SConscript
+++ b/vector/vmap3/SConscript
@@ -7,4 +7,7 @@ env.Program("vmap_fix_diff.cpp")
 
 env.Install(env.bindir, Split("""
   vmap_render
+  vmap_mmb_filter
+  vmap_1km_filter
+  vmap_fix_diff
 """))


### PR DESCRIPTION
`vmap_mmb_filter` and `vmap_fix_diff` binaries required by https://github.com/slazav/map_hr/blob/master/bin/make_in.sh script, but missed from mapsoft install package.